### PR TITLE
Distinguish health data by device to fix duplicate logging #95

### DIFF
--- a/Cozie.xcodeproj/project.pbxproj
+++ b/Cozie.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		CAE4FDB92CD28C7000B0B888 /* CozieStorageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA92EF82A53EE7700DA6A28 /* CozieStorageProtocol.swift */; };
 		CAE88C512D2B228D00EE8A83 /* TimeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE88C502D2B228600EE8A83 /* TimeModel.swift */; };
 		CAE88C552D2B22EF00EE8A83 /* TimeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE88C542D2B22EB00EE8A83 /* TimeModelTests.swift */; };
+		D1AE130A3052E90D008AFE77 /* HealthKitInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AE13093052E8F1008AFE77 /* HealthKitInteractorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -385,6 +386,7 @@
 		CAD1F0F72CCFC5A1001B5307 /* PushNotificationLoggerRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationLoggerRepositoryTests.swift; sourceTree = "<group>"; };
 		CAE88C502D2B228600EE8A83 /* TimeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeModel.swift; sourceTree = "<group>"; };
 		CAE88C542D2B22EB00EE8A83 /* TimeModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeModelTests.swift; sourceTree = "<group>"; };
+		D1AE13093052E8F1008AFE77 /* HealthKitInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitInteractorTests.swift; sourceTree = "<group>"; };
 		D24C4273B7B8B756FE8443A6 /* Pods-Cozie Watch App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Cozie Watch App.release.xcconfig"; path = "Target Support Files/Pods-Cozie Watch App/Pods-Cozie Watch App.release.xcconfig"; sourceTree = "<group>"; };
 		E183B343CF71E4B7667B905D /* Pods_OneSignalNotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OneSignalNotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F415053C9AB8896A79909F80 /* Pods-Cozie.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Cozie.release.xcconfig"; path = "Target Support Files/Pods-Cozie/Pods-Cozie.release.xcconfig"; sourceTree = "<group>"; };
@@ -1140,6 +1142,7 @@
 		CAC5D4EB2D3A685B006EF85B /* Interactors */ = {
 			isa = PBXGroup;
 			children = (
+				D1AE13083052E8AE008AFE77 /* HealthKitInteractorTests */,
 				CAC5D4EC2D3A6873006EF85B /* SettingsInteractorTests */,
 			);
 			path = Interactors;
@@ -1212,6 +1215,14 @@
 				CAE88C542D2B22EB00EE8A83 /* TimeModelTests.swift */,
 			);
 			path = TimeModelTests;
+			sourceTree = "<group>";
+		};
+		D1AE13083052E8AE008AFE77 /* HealthKitInteractorTests */ = {
+			isa = PBXGroup;
+			children = (
+				D1AE13093052E8F1008AFE77 /* HealthKitInteractorTests.swift */,
+			);
+			path = HealthKitInteractorTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1353,8 +1364,6 @@
 				en,
 			);
 			mainGroup = 921289C1299649EC0060C729;
-			packageReferences = (
-			);
 			productRefGroup = 921289CB299649EC0060C729 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1678,6 +1687,7 @@
 				CA7139952CF9A1B8003E7F41 /* OfflineManagerTests.swift in Sources */,
 				CAE88C552D2B22EF00EE8A83 /* TimeModelTests.swift in Sources */,
 				CAD1F0F82CCFC5B7001B5307 /* PushNotificationLoggerRepositoryTests.swift in Sources */,
+				D1AE130A3052E90D008AFE77 /* HealthKitInteractorTests.swift in Sources */,
 				CA9511DC2D366F5000BA4283 /* BackendSettingsStub.swift in Sources */,
 				CA9511D72D36615A00BA4283 /* SettingsInteractorMock.swift in Sources */,
 				CAC5D4F02D3A68F4006EF85B /* DataBaseStorageMock.swift in Sources */,

--- a/Cozie/Interactors/HealthKitInteractor/HealthKitInteractor.swift
+++ b/Cozie/Interactors/HealthKitInteractor/HealthKitInteractor.swift
@@ -19,7 +19,7 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
         case workout, sleep, apnea
     }
     
-    typealias HealthValue = (type: HealthValueType, key: String, startDate: Date, value: Double)
+    typealias HealthValue = (type: HealthValueType, key: String, startDate: Date, value: Double, device: HKDevice?)
     
     enum HeathDataKeys: String {
         case heartRateKey = "_heart_rate"
@@ -240,8 +240,8 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
                 }
                 var apneaSamples: [HealthValue] = []
                 apneaEventSamples.forEach { sample in
-                    apneaSamples.append((.apnea, HeathDataKeys.apneaEvent.rawValue, sample.startDate, sample.startDate.distance(to: sample.endDate)/60))
-                }
+                    apneaSamples.append((.apnea, HeathDataKeys.apneaEvent.rawValue, sample.startDate, sample.startDate.distance(to: sample.endDate)/60, sample.device))
+                    }
                 
                 completion([], apneaSamples, nil)
                 return
@@ -263,7 +263,7 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
                             lastSyncInterval = lastInterval
                         }
                         if lastInterval > lastSync {
-                            sleepData.append((.sleep, sleepKey, sleepSample.startDate, sleepSample.startDate.distance(to: sleepSample.endDate)/60))
+                            sleepData.append((.sleep, sleepKey, sleepSample.startDate, sleepSample.startDate.distance(to: sleepSample.endDate)/60, sleepSample.device))
                         }
                     }
                 }
@@ -283,8 +283,8 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
                             lastSyncInterval = lastInterval
                         }
                         if lastInterval > lastSync {
-                            workoutData.append((.workout, HeathDataKeys.workoutType.rawValue, sampleWorkout.startDate, Double(sampleWorkout.workoutActivityType.rawValue)))
-                            workoutData.append((.workout, HeathDataKeys.workoutDuration.rawValue, sampleWorkout.startDate, sampleWorkout.duration))
+                            workoutData.append((.workout, HeathDataKeys.workoutType.rawValue, sampleWorkout.startDate, Double(sampleWorkout.workoutActivityType.rawValue), sampleWorkout.device))
+                            workoutData.append((.workout, HeathDataKeys.workoutDuration.rawValue, sampleWorkout.startDate, sampleWorkout.duration, sampleWorkout.device))
                         }
                     }
                 }
@@ -394,23 +394,23 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
                     healthData.forEach { sample in
                         let customTrigger = self.addPrefixForDataKey(key: HeathDataKeys.apneaEventTrigger.rawValue)
                         
-                        healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: sample.startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: customTrigger, healthKey: self.addPrefixForDataKey(key: sample.key), healthValue: sample.value)))
+                        healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: sample.startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: customTrigger, healthKey: self.addPrefixForDataKey(key: sample.key, device: sample.device), healthValue: sample.value)))
                     }
                     completion(healthModels, samples)
                     
                     // With units (steps, hr...)
                 } else if healthData.first?.type == .workout {
-                    healthData.forEach { (type, workoutKey, startDate, value) in
+                    healthData.forEach { (type, workoutKey, startDate, value, device) in
                         if workoutKey == HeathDataKeys.workoutType.rawValue {
-                            healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: trigger, healthKey: self.addPrefixForDataKey(key: workoutKey), healthValue: value, healthStringValue: HKWorkoutActivityType(rawValue: UInt(value))?.name ?? "")))
+                            healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: trigger, healthKey: self.addPrefixForDataKey(key: workoutKey, device: device), healthValue: value, healthStringValue: HKWorkoutActivityType(rawValue: UInt(value))?.name ?? "")))
                         } else {
-                            healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: trigger, healthKey: self.addPrefixForDataKey(key: workoutKey), healthValue: value)))
+                            healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: trigger, healthKey: self.addPrefixForDataKey(key: workoutKey, device: device), healthValue: value)))
                         }
                     }
                     completion(healthModels, samples)
                 } else if healthData.first?.type == .sleep {
-                    healthData.forEach { (type, sleepKey, startDate, value) in
-                        healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: trigger, healthKey: self.addPrefixForDataKey(key: sleepKey), healthValue: value)))
+                    healthData.forEach { (type, sleepKey, startDate, value, device) in
+                        healthModels.append(HealthModel(time: self.healthDateFormatter.string(from: startDate), measurement: user.experimentID, tags: tag, fields: HealthFields(transmitTrigger: trigger, healthKey: self.addPrefixForDataKey(key: sleepKey, device: device), healthValue: value)))
                     }
                     completion(healthModels, samples)
                 }

--- a/Cozie/Interactors/HealthKitInteractor/HealthKitInteractor.swift
+++ b/Cozie/Interactors/HealthKitInteractor/HealthKitInteractor.swift
@@ -521,7 +521,7 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
         }
     }
     
-    private func addPrefixForDataKey(key: String, device: HKDevice? = nil) -> String {
+    static func addPrefixForDataKey(key: String, device: HKDevice?, dataPrefix: String) -> String {
         guard let device = device, let model = device.model else {
             return dataPrefix + key
         }
@@ -539,6 +539,10 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
         let suffix = "_\(manufacturer)_\(deviceModel)_\(uniquePart)".lowercased()
 
         return dataPrefix + key + suffix
+    }
+
+    private func addPrefixForDataKey(key: String, device: HKDevice? = nil) -> String {
+        Self.addPrefixForDataKey(key: key, device: device, dataPrefix: dataPrefix)
     }
     
     private func convertToUnit(sample: HKQuantitySample, type: HKSampleType, completion: @escaping (Double?) -> Void) {

--- a/Cozie/Interactors/HealthKitInteractor/HealthKitInteractor.swift
+++ b/Cozie/Interactors/HealthKitInteractor/HealthKitInteractor.swift
@@ -522,10 +522,23 @@ final class HealthKitInteractor: HealthKitInteractorProtocol {
     }
     
     private func addPrefixForDataKey(key: String, device: HKDevice? = nil) -> String {
-        if let name = device?.model {
-            return dataPrefix + key + (name.lowercased().contains("phone") ? HeathDataKeys.phone.rawValue : HeathDataKeys.watch.rawValue)
+        guard let device = device, let model = device.model else {
+            return dataPrefix + key
         }
-        return dataPrefix + key
+
+        if model.lowercased().contains("phone") {
+            return dataPrefix + key + HeathDataKeys.phone.rawValue
+        }
+
+        // Distinguish between multiple non-phone sources (e.g. two Apple Watches of
+        // the same model, or an Apple Watch alongside a Fitbit/Oura), instead of
+        // merging them all under one shared "_watch" suffix.
+        let manufacturer = (device.manufacturer ?? "").replacingOccurrences(of: " ", with: "")
+        let deviceModel = model.replacingOccurrences(of: " ", with: "")
+        let uniquePart = device.localIdentifier?.prefix(6) ?? ""
+        let suffix = "_\(manufacturer)_\(deviceModel)_\(uniquePart)".lowercased()
+
+        return dataPrefix + key + suffix
     }
     
     private func convertToUnit(sample: HKQuantitySample, type: HKSampleType, completion: @escaping (Double?) -> Void) {

--- a/CozieTests/Interactors/HealthKitInteractorTests/HealthKitInteractorTests.swift
+++ b/CozieTests/Interactors/HealthKitInteractorTests/HealthKitInteractorTests.swift
@@ -1,0 +1,88 @@
+//
+//  HealthKitInteractorTests.swift
+//  Cozie
+//
+//  Created by Tesoro on 2026/9/10.
+//
+import Testing
+import HealthKit
+@testable import Cozie
+
+@Suite("HealthKitInteractor")
+struct HealthKitInteractorTests {
+
+    @Test("Two Apple Watches of the same model get different keys")
+    func sameModelDifferentIdentifierProducesDifferentKeys() {
+        let watch1 = HKDevice(name: "Apple Watch",
+                               manufacturer: "Apple Inc.",
+                               model: "Watch7,1",
+                               hardwareVersion: nil,
+                               firmwareVersion: nil,
+                               softwareVersion: nil,
+                               localIdentifier: "AAAAAA-1111-1111-1111-111111111111",
+                               udiDeviceIdentifier: nil)
+
+        let watch2 = HKDevice(name: "Apple Watch",
+                               manufacturer: "Apple Inc.",
+                               model: "Watch7,1",
+                               hardwareVersion: nil,
+                               firmwareVersion: nil,
+                               softwareVersion: nil,
+                               localIdentifier: "BBBBBB-2222-2222-2222-222222222222",
+                               udiDeviceIdentifier: nil)
+
+        let key1 = HealthKitInteractor.addPrefixForDataKey(key: "steps", device: watch1, dataPrefix: "ts")
+        let key2 = HealthKitInteractor.addPrefixForDataKey(key: "steps", device: watch2, dataPrefix: "ts")
+
+        #expect(key1 != key2)
+    }
+
+    @Test("Apple Watch and a third-party device get different keys")
+    func differentManufacturersProduceDifferentKeys() {
+        let appleWatch = HKDevice(name: "Apple Watch",
+                                   manufacturer: "Apple Inc.",
+                                   model: "Watch7,1",
+                                   hardwareVersion: nil,
+                                   firmwareVersion: nil,
+                                   softwareVersion: nil,
+                                   localIdentifier: "AAAAAA-1111",
+                                   udiDeviceIdentifier: nil)
+
+        let fitbit = HKDevice(name: "Fitbit",
+                               manufacturer: "Fitbit",
+                               model: "Versa",
+                               hardwareVersion: nil,
+                               firmwareVersion: nil,
+                               softwareVersion: nil,
+                               localIdentifier: "CCCCCC-3333",
+                               udiDeviceIdentifier: nil)
+
+        let key1 = HealthKitInteractor.addPrefixForDataKey(key: "steps", device: appleWatch, dataPrefix: "ts")
+        let key2 = HealthKitInteractor.addPrefixForDataKey(key: "steps", device: fitbit, dataPrefix: "ts")
+
+        #expect(key1 != key2)
+    }
+
+    @Test("iPhone-sourced data still uses the _phone suffix")
+    func phoneDeviceStillUsesPhoneSuffix() {
+        let iphone = HKDevice(name: "iPhone",
+                               manufacturer: "Apple Inc.",
+                               model: "iPhone",
+                               hardwareVersion: nil,
+                               firmwareVersion: nil,
+                               softwareVersion: nil,
+                               localIdentifier: nil,
+                               udiDeviceIdentifier: nil)
+
+        let key = HealthKitInteractor.addPrefixForDataKey(key: "steps", device: iphone, dataPrefix: "ts")
+
+        #expect(key == "tssteps_phone")
+    }
+
+    @Test("No device falls back to prefix + key only")
+    func noDeviceReturnsPrefixPlusKey() {
+        let key = HealthKitInteractor.addPrefixForDataKey(key: "steps", device: nil, dataPrefix: "ts")
+
+        #expect(key == "tssteps")
+    }
+}


### PR DESCRIPTION
**Summary**
Fixes the duplicate health data problem described in #95 (steps, sleep time, etc. logged twice when a user has more than one wearable device feeding HealthKit).
**Root cause**
getLastDaySamples() only filters by time, not by source, so it pulls in data from every device. There was already partial handling for this (addPrefixForDataKey() splits phone vs. watch data into separate fields), but everything non-phone still got lumped into one _watch bucket — so two watches, or a watch + third-party device, still collide.
**Approach**
Of the two options in the issue ("let the user pick a source in settings" vs. "log the data separately per device"), I went with logging separately per device — no new UI, smaller change, and it fits the existing _phone/_watch suffix pattern already in the codebase.
addPrefixForDataKey() now builds a per-device suffix from manufacturer + model + the first 6 characters of localIdentifier, instead of a flat _watch for everything non-phone. This means: Two Apple Watches of the same model now produce distinct fields (localIdentifier differs per physical device pairing). Apple Watch + Fitbit/Oura now produce distinct fields (manufacturer/model differ). Phone-sourced data is untouched, still _phone.
The key-building logic was pulled out into a standalone static func addPrefixForDataKey(key:device:dataPrefix:) (the instance method now just delegates to it) so it could be unit tested without needing to construct the full interactor's dependency graph.
**Update**
The device-tagging was initially only wired through the step count / distance path. Followed the same pattern through the sleep and workout pipelines too, so those are now covered as well.
**Heads up**
This changes field names for non-phone data going forward (_watch → something like _apple_watch7,1_a1b2c3). Flagging in case that breaks any dashboards querying the old field name.
@mariofrei — does this approach work, or would you rather do the settings-based picker instead? Also let me know if the renamed fields are a problem for existing data.
**Testing**
Builds fine. Added 4 unit tests covering: two same-model watches get different keys, watch vs. third-party device get different keys, phone data unaffected, no-device fallback still works — all passing. Haven't tested on a real device with two paired wearables (don't have a second one on hand).
**AI use**
Used Codex to search the codebase and help pin down where the issue actually was. Once I found the right spot, I made the code changes myself. Verified it with 4 unit tests I wrote and ran in Xcode — all passing, plus confirmed the build still works.


