### PR TITLE
Fix #101: Stop resetting local backup file when Participant ID changes

### DIFF
--- a/Cozie/Interactors/LoggerInteractor/LoggerInteractor.swift
+++ b/Cozie/Interactors/LoggerInteractor/LoggerInteractor.swift
@@ -15,6 +15,7 @@ final class LoggerInteractor: LoggerProtocol {
     let semaphore = DispatchSemaphore(value: 1)
     let writeQueue = DispatchQueue.global(qos: .userInitiated)
     
+    private let backupFileNameKey = "cozieLocalBackupFileName"
     // MARK: Private
     private enum Constants: String {
         case fileNamePrefix = "cozie_"
@@ -48,10 +49,27 @@ final class LoggerInteractor: LoggerProtocol {
         return name
     }
     
+    private func backupFileURL(user: User) -> URL {
+        let defaults = UserDefaults.standard
+
+        if let savedFileName = defaults.string(forKey: backupFileNameKey) {
+            return getDocumentsDirectory()
+                .appendingPathComponent(savedFileName)
+        }
+
+        let fileName = buildFileName(
+            additionalName: userFileName(user: user)
+        )
+
+        defaults.set(fileName, forKey: backupFileNameKey)
+
+        return getDocumentsDirectory()
+            .appendingPathComponent(fileName)
+    }
     // MARK: Public
     func logInfo(action: String, info: String) {
         if let currentUser = userInteractor.currentUser {
-            let filename = getDocumentsDirectory().appendingPathComponent(buildFileName(additionalName: userFileName(user: currentUser)))
+            let filename = backupFileURL(user: currentUser)
             writeQueue.async { [weak self] in
                 self?.semaphore.wait()
                 do {
@@ -82,7 +100,7 @@ final class LoggerInteractor: LoggerProtocol {
     // TODO: - Unit Tests
     func loggedInfo(completion:((_ url: URL?,_ error: String?) -> ())?) {
         if let currentUser = userInteractor.currentUser {
-            let filename = getDocumentsDirectory().appendingPathComponent(buildFileName(additionalName: userFileName(user: currentUser)))
+            let filename = backupFileURL(user: currentUser)
             
             if FileManager.default.fileExists(atPath: filename.relativePath) {
                 completion?(filename, nil)


### PR DESCRIPTION
Previously, the local backup file name was generated using the current Experiment ID and Participant ID. When the Participant ID changed, the app started using a different backup file, so the previous logs appeared to be reset.

I updated the backup file logic so that the app saves and reuses the original backup file name. This means that changing the Participant ID will no longer create a new local backup file.

I tested the fix by:
- reproducing the issue before the change
- changing the Participant ID
- restarting the app
- downloading and checking the backup file

After the fix, the app continued using the same backup file, and both the old and new logs were kept in that file.

Fixes #101